### PR TITLE
Add support for associative operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ use Cache::LRU;
 my $cache = Cache::LRU.new(size => 1024);
 
 $cache.set($key, $value);
+# Or $cache{$key} = $value
 
 my $value = $cache.get($key);
 
 my $removed_value = $cache.remove($key);
+# Or $cache{$key}:delete
 
 ```
 
@@ -21,6 +23,9 @@ my $removed_value = $cache.remove($key);
 
 Cache::LRU is a simple, fast implementation of an in-memory LRU cache in
 pure perl.
+
+This class implements the associative interface, so in most cases it can
+be used as a regular Hash.
 
 ## FUNCTIONS
 
@@ -33,7 +38,7 @@ size is default 1024.
 ### $cache.get($key)
 Returns the cached object if exists, or undef otherwise.
 
-### $cache.set($key => $value)
+### $cache.set($key, $value)
 Stores the given key-value pair.
 
 ### $cache.remove($key)

--- a/lib/Cache/LRU.pm
+++ b/lib/Cache/LRU.pm
@@ -69,4 +69,18 @@ class Cache::LRU {
         %!entries = ();
         @!fifo = ();
     }
+
+    # Associative role methods
+
+    multi method AT-KEY (::?CLASS:D: $key) is rw {
+        my $cache = self;
+        Proxy.new(
+            FETCH => method () { $cache.get($key) },
+            STORE => method ($value) { $cache.set( $key, $value ) },
+        );
+    }
+
+    multi method EXISTS-KEY (::?CLASS:D: $key) { %!entries{$key}:exists }
+
+    multi method DELETE-KEY (::?CLASS:D: $key) { $.remove($key) }
 }

--- a/t/00base.t
+++ b/t/00base.t
@@ -46,5 +46,13 @@ $cache.clear;
 ok ! defined $cache.get('c');
 ok ! defined $cache.get('e');
 
+# Supports associative operations
+is ( $cache< a b c > = 1, 2, 3 ), ( 1, 2, 3);
+ok $cache<a>:exists;
+is $cache<a>, 1;
+is ++$cache<b>, 3;
+is $cache<c>:delete, 3;
+ok $cache<c>:!exists;
+
 done-testing;
 


### PR DESCRIPTION
The motivation for this patch was finding that the example in the synopsis

```
$cache.set( $key => $value );
```

did not work because that would pass a single Pair object to `set` rather than a plain key and a value.

When looking at how support for that could be implemented, I realised implementing the [Associative](https://docs.raku.org/type/Associative) interface made for a more elegant solution, so the above snippet could be turned into a more natural

```
$cache{$key} = $value;
```

I've added some mention of this in the documentation.